### PR TITLE
Remove argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 colorama==0.4.4
 progressbar33==2.4
 requests==2.24.0
-argparse


### PR DESCRIPTION
`argparse` is a [Python standard module](https://docs.python.org/3/library/argparse.html).